### PR TITLE
Add nightly ETL workflow

### DIFF
--- a/.github/workflows/nightly-etl.yml
+++ b/.github/workflows/nightly-etl.yml
@@ -1,0 +1,31 @@
+name: Nightly ETL
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-etl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas requests pysleeper
+      - name: Run ETL
+        run: python etl/build_dataset.py --output-dir public
+      - name: Commit and push
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add public
+          git commit -m "Update dataset [skip ci]" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
## Summary
- add scheduled GitHub Actions workflow to run nightly ETL

## Testing
- `python etl/build_dataset.py --year 2023 --output-dir public` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6853526a7298832697eee99b2870486b