### PR TITLE
Add league import page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "tamagui": "^1.92.0",
     "zustand": "^4.4.2",
     "dexie": "^3.2.4",
-    "recharts": "^2.9.0"
+    "recharts": "^2.9.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,16 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
+import ImportLeague from './pages/ImportLeague'
 
 function App() {
-  return <Home />
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/import-league" element={<ImportLeague />} />
+      </Routes>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,11 @@
+import { Link } from 'react-router-dom'
+
 export default function Home() {
   return (
     <main>
       <h1>Welcome to Fantasy Draft Assistant</h1>
       <p>Get ready to draft the perfect team!</p>
+      <Link to="/import-league">Import League</Link>
     </main>
   )
 }

--- a/src/pages/ImportLeague.tsx
+++ b/src/pages/ImportLeague.tsx
@@ -1,0 +1,41 @@
+import { FormEvent, useState } from 'react'
+import { useLeagueStore } from '../state/leagueStore'
+
+export default function ImportLeague() {
+  const [leagueId, setLeagueId] = useState('')
+  const setRosterSlots = useLeagueStore((s) => s.setRosterSlots)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!leagueId) return
+    try {
+      const resp = await fetch(
+        `https://api.sleeper.app/v1/league/${leagueId}`
+      )
+      if (!resp.ok) throw new Error('Failed to fetch league')
+      const data = await resp.json()
+      const slots = data.roster_positions || data.settings?.roster_positions
+      if (Array.isArray(slots)) {
+        setRosterSlots(slots)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <main>
+      <h1>Import League</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          League ID:
+          <input
+            value={leagueId}
+            onChange={(e) => setLeagueId(e.target.value)}
+          />
+        </label>
+        <button type="submit">Import</button>
+      </form>
+    </main>
+  )
+}

--- a/src/state/leagueStore.ts
+++ b/src/state/leagueStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface LeagueState {
+  rosterSlots: string[]
+  setRosterSlots: (slots: string[]) => void
+}
+
+export const useLeagueStore = create<LeagueState>((set) => ({
+  rosterSlots: [],
+  setRosterSlots: (slots) => set({ rosterSlots: slots }),
+}))


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- add Zustand league store
- create `/import-league` page with form to load Sleeper league
- wire up React Router and link from home

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853527662c883269ae13e1aa9c71df0