### PR TITLE
Add draft board components with Dexie persistence

### DIFF
--- a/public/players_2024.json
+++ b/public/players_2024.json
@@ -1,0 +1,7 @@
+[
+  {"id": 1, "name": "Christian McCaffrey", "position": "RB", "team": "SF"},
+  {"id": 2, "name": "Justin Jefferson", "position": "WR", "team": "MIN"},
+  {"id": 3, "name": "Ja'Marr Chase", "position": "WR", "team": "CIN"},
+  {"id": 4, "name": "Travis Kelce", "position": "TE", "team": "KC"},
+  {"id": 5, "name": "Bijan Robinson", "position": "RB", "team": "ATL"}
+]

--- a/src/components/DraftPicks.tsx
+++ b/src/components/DraftPicks.tsx
@@ -1,0 +1,27 @@
+import { useDraftStore } from '../store'
+
+export default function DraftPicks() {
+  const picks = useDraftStore((s) => s.picks)
+  const players = useDraftStore((s) => s.players)
+  const undoPick = useDraftStore((s) => s.undoPick)
+
+  const sorted = [...picks].sort((a, b) => a.timestamp - b.timestamp)
+
+  return (
+    <div>
+      <h2>Draft Picks</h2>
+      <ol>
+        {sorted.map((p) => {
+          const player = players.find((pl) => pl.id === p.playerId)
+          if (!player) return null
+          return (
+            <li key={p.id}>
+              {player.name}{' '}
+              <button onClick={() => undoPick(p.id!)}>Undo</button>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,0 +1,25 @@
+import { useDraftStore } from '../store'
+
+export default function PlayerList() {
+  const players = useDraftStore((s) => s.players)
+  const picks = useDraftStore((s) => s.picks)
+  const toggleTaken = useDraftStore((s) => s.toggleTaken)
+
+  const isTaken = (id: number) => picks.some((p) => p.playerId === id)
+
+  return (
+    <div>
+      <h2>Available Players</h2>
+      <ul>
+        {players
+          .filter((p) => !isTaken(p.id))
+          .map((p) => (
+            <li key={p.id}>
+              {p.name} ({p.position}-{p.team}){' '}
+              <button onClick={() => toggleTaken(p.id)}>Taken</button>
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,20 @@
+import Dexie, { Table } from 'dexie'
+
+export interface DraftPick {
+  id?: number
+  playerId: number
+  timestamp: number
+}
+
+class DraftDB extends Dexie {
+  picks!: Table<DraftPick, number>
+
+  constructor() {
+    super('draftDB')
+    this.version(1).stores({
+      picks: '++id,playerId,timestamp',
+    })
+  }
+}
+
+export const db = new DraftDB()

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,22 @@
+import { useEffect } from 'react'
+import PlayerList from '../components/PlayerList'
+import DraftPicks from '../components/DraftPicks'
+import { useDraftStore } from '../store'
+
 export default function Home() {
+  const loadPlayers = useDraftStore((s) => s.loadPlayers)
+
+  useEffect(() => {
+    loadPlayers()
+  }, [loadPlayers])
+
   return (
     <main>
-      <h1>Welcome to Fantasy Draft Assistant</h1>
-      <p>Get ready to draft the perfect team!</p>
+      <h1>Fantasy Draft Assistant</h1>
+      <div style={{ display: 'flex', gap: '2rem' }}>
+        <PlayerList />
+        <DraftPicks />
+      </div>
     </main>
   )
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand'
+import { db, DraftPick } from './db'
+
+export interface Player {
+  id: number
+  name: string
+  position: string
+  team: string
+}
+
+interface DraftState {
+  players: Player[]
+  picks: DraftPick[]
+  loadPlayers: () => Promise<void>
+  toggleTaken: (playerId: number) => Promise<void>
+  undoPick: (id: number) => Promise<void>
+}
+
+export const useDraftStore = create<DraftState>((set, get) => ({
+  players: [],
+  picks: [],
+  loadPlayers: async () => {
+    const res = await fetch('/players_2024.json')
+    const players: Player[] = await res.json()
+    const picks = await db.picks.toArray()
+    set({ players, picks })
+  },
+  toggleTaken: async (playerId: number) => {
+    const state = get()
+    const existing = state.picks.find((p) => p.playerId === playerId)
+    if (existing && existing.id !== undefined) {
+      await db.picks.delete(existing.id)
+      set({ picks: state.picks.filter((p) => p.playerId !== playerId) })
+    } else {
+      const pick: DraftPick = { playerId, timestamp: Date.now() }
+      const id = await db.picks.add(pick)
+      set({ picks: [...state.picks, { ...pick, id }] })
+    }
+  },
+  undoPick: async (id: number) => {
+    await db.picks.delete(id)
+    set((state) => ({ picks: state.picks.filter((p) => p.id !== id) }))
+  },
+}))


### PR DESCRIPTION
## Summary
- include sample players JSON
- implement Dexie draft DB
- add zustand store for players and picks
- create PlayerList and DraftPicks components
- integrate components in Home page

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6853528659c08326a4d2655da5a35a60