### PR TITLE
Add scoring engine with adjustable weights

### DIFF
--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,7 +1,8 @@
 import { useDraftStore } from '../store'
+import { useScoredPlayers } from '../hooks/useScoredPlayers'
 
 export default function PlayerList() {
-  const players = useDraftStore((s) => s.players)
+  const players = useScoredPlayers()
   const picks = useDraftStore((s) => s.picks)
   const toggleTaken = useDraftStore((s) => s.toggleTaken)
 
@@ -15,7 +16,7 @@ export default function PlayerList() {
           .filter((p) => !isTaken(p.id))
           .map((p) => (
             <li key={p.id}>
-              {p.name} ({p.position}-{p.team}){' '}
+              {p.name} ({p.position}-{p.team}) - {p.score.toFixed(2)}{' '}
               <button onClick={() => toggleTaken(p.id)}>Taken</button>
             </li>
           ))}

--- a/src/components/ScoringSliders.tsx
+++ b/src/components/ScoringSliders.tsx
@@ -1,0 +1,35 @@
+import { useScoringStore } from '../state/scoringStore'
+
+const entries = [
+  ['vor', 'VOR'],
+  ['dropoff', 'Drop-Off'],
+  ['bye', 'Bye Week'],
+  ['need', 'Roster Need'],
+  ['flag', 'Flag Boost'],
+] as const
+
+export default function ScoringSliders() {
+  const weights = useScoringStore((s) => s.weights)
+  const setWeights = useScoringStore((s) => s.setWeights)
+
+  return (
+    <div>
+      <h3>Weighting</h3>
+      {entries.map(([key, label]) => (
+        <label key={key} style={{ display: 'block' }}>
+          {label}: {weights[key].toFixed(1)}
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.1}
+            value={weights[key]}
+            onChange={(e) =>
+              setWeights({ [key]: parseFloat(e.target.value) } as any)
+            }
+          />
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/src/hooks/useScoredPlayers.ts
+++ b/src/hooks/useScoredPlayers.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react'
+import { useDraftStore, Player } from '../store'
+import { useLeagueStore } from '../state/leagueStore'
+import { useScoringStore } from '../state/scoringStore'
+import { scorePlayer, ScoreContext } from '../utils/scoring'
+
+export interface ScoredPlayer extends Player {
+  score: number
+}
+
+export function useScoredPlayers(): ScoredPlayer[] {
+  const players = useDraftStore((s) => s.players)
+  const picks = useDraftStore((s) => s.picks)
+  const rosterSlots = useLeagueStore((s) => s.rosterSlots)
+  const weights = useScoringStore((s) => s.weights)
+
+  return useMemo(() => {
+    const byeWeekCounts: Record<number, number> = {}
+    const positionCounts: Record<string, number> = {}
+
+    for (const pick of picks) {
+      const player = players.find((p) => p.id === pick.playerId)
+      if (!player) continue
+      if (player.byeWeek !== undefined) {
+        byeWeekCounts[player.byeWeek] =
+          (byeWeekCounts[player.byeWeek] || 0) + 1
+      }
+      positionCounts[player.position] =
+        (positionCounts[player.position] || 0) + 1
+    }
+
+    const maxPositions: Record<string, number> = {}
+    for (const slot of rosterSlots) {
+      maxPositions[slot] = (maxPositions[slot] || 0) + 1
+    }
+
+    const rosterNeeds: Record<string, number> = {}
+    for (const pos in maxPositions) {
+      rosterNeeds[pos] = Math.max(
+        0,
+        maxPositions[pos] - (positionCounts[pos] || 0)
+      )
+    }
+
+    const ctx: ScoreContext = { byeWeekCounts, rosterNeeds }
+
+    const scored = players.map((p) => ({
+      ...p,
+      score: scorePlayer(p, weights, ctx),
+    }))
+
+    return scored.sort((a, b) => b.score - a.score)
+  }, [players, picks, rosterSlots, weights])
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from 'react'
 import PlayerList from '../components/PlayerList'
 import DraftPicks from '../components/DraftPicks'
+import ScoringSliders from '../components/ScoringSliders'
 import { useDraftStore } from '../store'
 import { Link } from 'react-router-dom'
 
@@ -15,6 +16,7 @@ export default function Home() {
   return (
     <main>
       <h1>Fantasy Draft Assistant</h1>
+      <ScoringSliders />
       <div style={{ display: 'flex', gap: '2rem' }}>
         <PlayerList />
         <DraftPicks />

--- a/src/state/scoringStore.ts
+++ b/src/state/scoringStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand'
+
+export interface ScoreWeights {
+  vor: number
+  dropoff: number
+  bye: number
+  need: number
+  flag: number
+}
+
+interface ScoringState {
+  weights: ScoreWeights
+  setWeights: (w: Partial<ScoreWeights>) => void
+}
+
+const defaultWeights: ScoreWeights = {
+  vor: 1,
+  dropoff: 1,
+  bye: 1,
+  need: 1,
+  flag: 1,
+}
+
+export const useScoringStore = create<ScoringState>((set) => ({
+  weights: defaultWeights,
+  setWeights: (w) => set((state) => ({ weights: { ...state.weights, ...w } })),
+}))

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,14 @@ export interface Player {
   name: string
   position: string
   team: string
+  /** value over replacement */
+  vor?: number
+  /** positional drop-off score */
+  dropOff?: number
+  /** bye week number */
+  byeWeek?: number
+  /** user flag boost (positive or negative) */
+  flagBoost?: number
 }
 
 interface DraftState {

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -1,0 +1,20 @@
+import { Player } from '../store'
+import { ScoreWeights } from '../state/scoringStore'
+
+export interface ScoreContext {
+  byeWeekCounts: Record<number, number>
+  rosterNeeds: Record<string, number>
+}
+
+export function scorePlayer(
+  player: Player,
+  weights: ScoreWeights,
+  ctx: ScoreContext
+): number {
+  const vor = (player.vor ?? 0) * weights.vor
+  const dropOff = (player.dropOff ?? 0) * weights.dropoff
+  const byeAdj = -(ctx.byeWeekCounts[player.byeWeek ?? -1] ?? 0) * weights.bye
+  const need = (ctx.rosterNeeds[player.position] ?? 0) * weights.need
+  const flag = (player.flagBoost ?? 0) * weights.flag
+  return vor + dropOff + byeAdj + need + flag
+}


### PR DESCRIPTION
## Summary
- extend `Player` with VOR, drop-off, bye, and flag boost fields
- add `scorePlayer` util and zustand store for weight settings
- create `useScoredPlayers` hook to score and sort players
- show sliders to tune weights and display sorted players with scores

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68535a2d9c2c8326b1c4d852f12ac884