### PR TITLE
Add fuzzy search and filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "dexie": "^3.2.4",
+        "fuse.js": "^6.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.23.0",
@@ -4988,6 +4989,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "dexie": "^3.2.4",
+    "fuse.js": "^6.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tamagui": "^1.92.0",
-    "zustand": "^4.4.2",
-    "dexie": "^3.2.4",
+    "react-router-dom": "^6.23.0",
     "recharts": "^2.9.0",
-    "react-router-dom": "^6.23.0"
+    "tamagui": "^1.92.0",
+    "zustand": "^4.4.2"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/public/players_2024.json
+++ b/public/players_2024.json
@@ -1,7 +1,7 @@
 [
-  {"id": 1, "name": "Christian McCaffrey", "position": "RB", "team": "SF"},
-  {"id": 2, "name": "Justin Jefferson", "position": "WR", "team": "MIN"},
-  {"id": 3, "name": "Ja'Marr Chase", "position": "WR", "team": "CIN"},
-  {"id": 4, "name": "Travis Kelce", "position": "TE", "team": "KC"},
-  {"id": 5, "name": "Bijan Robinson", "position": "RB", "team": "ATL"}
+  {"id": 1, "name": "Christian McCaffrey", "position": "RB", "team": "SF", "vor": 100, "injured": false},
+  {"id": 2, "name": "Justin Jefferson", "position": "WR", "team": "MIN", "vor": 98, "injured": false},
+  {"id": 3, "name": "Ja'Marr Chase", "position": "WR", "team": "CIN", "vor": 95, "injured": false},
+  {"id": 4, "name": "Travis Kelce", "position": "TE", "team": "KC", "vor": 85, "injured": true},
+  {"id": 5, "name": "Bijan Robinson", "position": "RB", "team": "ATL", "vor": 90, "injured": false}
 ]

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from 'react'
+import Fuse from 'fuse.js'
 import { useDraftStore } from '../store'
 import { useScoredPlayers } from '../hooks/useScoredPlayers'
 
@@ -6,20 +8,80 @@ export default function PlayerList() {
   const picks = useDraftStore((s) => s.picks)
   const toggleTaken = useDraftStore((s) => s.toggleTaken)
 
+  const [query, setQuery] = useState('')
+  const [pos, setPos] = useState<string>('ALL')
+  const [hideDrafted, setHideDrafted] = useState(true)
+  const [hideInjured, setHideInjured] = useState(false)
+
   const isTaken = (id: number) => picks.some((p) => p.playerId === id)
+
+  const tierBreaks = useMemo(() => {
+    const sorted = [...players].sort((a, b) => (b.vor ?? 0) - (a.vor ?? 0))
+    const breaks = new Set<number>()
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const cur = sorted[i].vor ?? 0
+      const next = sorted[i + 1].vor ?? 0
+      if (cur - next >= 10) {
+        breaks.add(sorted[i].id)
+      }
+    }
+    return breaks
+  }, [players])
+
+  const filtered = players
+    .filter((p) => (pos === 'ALL' ? true : p.position === pos))
+    .filter((p) => (hideDrafted ? !isTaken(p.id) : true))
+    .filter((p) => (hideInjured ? !p.injured : true))
+
+  const fuse = useMemo(() => new Fuse(filtered, { keys: ['name', 'team'] }), [filtered])
+
+  const results = query ? fuse.search(query).map((r) => r.item) : filtered
 
   return (
     <div>
       <h2>Available Players</h2>
+      <input
+        placeholder="Search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <div>
+        {['ALL', 'QB', 'RB', 'WR', 'TE'].map((p) => (
+          <button
+            key={p}
+            onClick={() => setPos(p)}
+            style={{ fontWeight: pos === p ? 'bold' : 'normal' }}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+      <label>
+        <input
+          type="checkbox"
+          checked={hideDrafted}
+          onChange={(e) => setHideDrafted(e.target.checked)}
+        />
+        Hide Drafted
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={hideInjured}
+          onChange={(e) => setHideInjured(e.target.checked)}
+        />
+        Hide Injured
+      </label>
       <ul>
-        {players
-          .filter((p) => !isTaken(p.id))
-          .map((p) => (
-            <li key={p.id}>
-              {p.name} ({p.position}-{p.team}) - {p.score.toFixed(2)}{' '}
-              <button onClick={() => toggleTaken(p.id)}>Taken</button>
-            </li>
-          ))}
+        {results.map((p) => (
+          <li key={p.id}>
+            {p.name} ({p.position}-{p.team}) - {p.score.toFixed(2)}{' '}
+            {tierBreaks.has(p.id) && <span style={{ color: 'red' }}>⚠ Last Tier</span>}{' '}
+            <button onClick={() => toggleTaken(p.id)}>
+              {isTaken(p.id) ? 'Undo' : 'Taken'}
+            </button>
+          </li>
+        ))}
       </ul>
     </div>
   )

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,8 @@ export interface Player {
   byeWeek?: number
   /** user flag boost (positive or negative) */
   flagBoost?: number
+  /** injury status */
+  injured?: boolean
 }
 
 interface DraftState {


### PR DESCRIPTION
## Summary
- add fuse.js dependency
- flag injured players in dataset
- support fuzzy search, position tabs, and filters in PlayerList
- warn when player is last in VOR tier

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68545b91faa483268a24ee39bb3f2361