### PR TITLE
Add bye week heatmap and player flags

### DIFF
--- a/src/components/ByeWeekHeatmap.tsx
+++ b/src/components/ByeWeekHeatmap.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
+import { useDraftStore } from '../store'
+import { useLeagueStore } from '../state/leagueStore'
+
+export default function ByeWeekHeatmap() {
+  const players = useDraftStore((s) => s.players)
+  const picks = useDraftStore((s) => s.picks)
+  const rosterSlots = useLeagueStore((s) => s.rosterSlots)
+
+  const { data, warnings } = useMemo(() => {
+    const maxPositions: Record<string, number> = {}
+    rosterSlots.forEach((pos) => {
+      maxPositions[pos] = (maxPositions[pos] || 0) + 1
+    })
+
+    const takenByPos: Record<string, number> = {}
+    const starters: number[] = []
+    const sorted = [...picks].sort((a, b) => a.timestamp - b.timestamp)
+    for (const pick of sorted) {
+      const player = players.find((p) => p.id === pick.playerId)
+      if (!player) continue
+      const pos = player.position
+      if ((takenByPos[pos] || 0) < (maxPositions[pos] || 0)) {
+        takenByPos[pos] = (takenByPos[pos] || 0) + 1
+        starters.push(player.id)
+      }
+    }
+
+    const weekCounts: Record<number, number> = {}
+    starters.forEach((id) => {
+      const player = players.find((p) => p.id === id)
+      if (!player || player.byeWeek === undefined) return
+      weekCounts[player.byeWeek] = (weekCounts[player.byeWeek] || 0) + 1
+    })
+
+    const warnings: number[] = []
+    for (const w in weekCounts) {
+      if (weekCounts[w] >= 3) warnings.push(Number(w))
+    }
+
+    const data = Array.from({ length: 18 }, (_, i) => ({
+      week: i + 1,
+      count: weekCounts[i + 1] || 0,
+    }))
+
+    return { data, warnings }
+  }, [players, picks, rosterSlots])
+
+  const colorScale = (count: number) => {
+    if (count >= 3) return '#d73027'
+    if (count === 2) return '#fc8d59'
+    if (count === 1) return '#fee08b'
+    return '#ffffbf'
+  }
+
+  if (!rosterSlots.length) return null
+
+  return (
+    <div>
+      <h3>Starters By Bye Week</h3>
+      <ResponsiveContainer width="100%" height={150}>
+        <BarChart data={data} margin={{ left: -20, right: 10, top: 10, bottom: 0 }}>
+          <XAxis dataKey="week" tickLine={false} />
+          <YAxis hide />
+          <Tooltip />
+          <Bar dataKey="count">
+            {data.map((d, idx) => (
+              <Cell key={idx} fill={colorScale(d.count)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+      {warnings.map((w) => (
+        <div key={w} style={{ color: 'red' }}>
+          ⚠ Many starters share bye week {w}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -7,6 +7,7 @@ export default function PlayerList() {
   const players = useScoredPlayers()
   const picks = useDraftStore((s) => s.picks)
   const toggleTaken = useDraftStore((s) => s.toggleTaken)
+  const setFlagColor = useDraftStore((s) => s.setFlagColor)
 
   const [query, setQuery] = useState('')
   const [pos, setPos] = useState<string>('ALL')
@@ -75,11 +76,30 @@ export default function PlayerList() {
       <ul>
         {results.map((p) => (
           <li key={p.id}>
-            {p.name} ({p.position}-{p.team}) - {p.score.toFixed(2)}{' '}
+            <span
+              style={{
+                backgroundColor: p.flagColor || 'transparent',
+                padding: '0 0.25rem',
+              }}
+            >
+              {p.name}
+            </span>{' '}
+            ({p.position}-{p.team}) - {p.score.toFixed(2)}{' '}
             {tierBreaks.has(p.id) && <span style={{ color: 'red' }}>⚠ Last Tier</span>}{' '}
             <button onClick={() => toggleTaken(p.id)}>
               {isTaken(p.id) ? 'Undo' : 'Taken'}
-            </button>
+            </button>{' '}
+            <input
+              type="color"
+              value={p.flagColor || '#ffffff'}
+              onChange={(e) =>
+                setFlagColor(
+                  p.id,
+                  e.target.value === '#ffffff' ? null : e.target.value
+                )
+              }
+              style={{ verticalAlign: 'middle', marginLeft: '0.5rem' }}
+            />
           </li>
         ))}
       </ul>

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,13 +7,24 @@ export interface DraftPick {
   timestamp: number
 }
 
+export interface PlayerFlag {
+  id?: number
+  playerId: number
+  color: string
+}
+
 class DraftDB extends Dexie {
   picks!: Table<DraftPick, number>
+  flags!: Table<PlayerFlag, number>
 
   constructor() {
     super('draftDB')
     this.version(1).stores({
       picks: '++id,session,playerId,timestamp',
+    })
+    this.version(2).stores({
+      picks: '++id,session,playerId,timestamp',
+      flags: '++id,playerId,color',
     })
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import PlayerList from '../components/PlayerList'
 import DraftPicks from '../components/DraftPicks'
 import ScoringSliders from '../components/ScoringSliders'
+import ByeWeekHeatmap from '../components/ByeWeekHeatmap'
 import { useDraftStore } from '../store'
 import { Link } from 'react-router-dom'
 
@@ -21,6 +22,7 @@ export default function Home() {
         <PlayerList />
         <DraftPicks />
       </div>
+      <ByeWeekHeatmap />
       <h1>Welcome to Fantasy Draft Assistant</h1>
       <p>Get ready to draft the perfect team!</p>
       <Link to="/import-league">Import League</Link>


### PR DESCRIPTION
## Summary
- track user flags in Dexie and store
- add color picker for players
- visualize starter bye weeks with heat map and warnings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68545e528ddc832699780e331e477e24